### PR TITLE
Capture Registries even earlier

### DIFF
--- a/src/main/java/com/terraformersmc/biolith/impl/biome/BiomeCoordinator.java
+++ b/src/main/java/com/terraformersmc/biolith/impl/biome/BiomeCoordinator.java
@@ -29,7 +29,7 @@ public class BiomeCoordinator {
     protected static DynamicRegistryManager.Immutable registryManager;
 
     public static void setRegistryManager(CombinedDynamicRegistries<ServerDynamicRegistryType> combinedDynamicRegistries) {
-        // Called by biolith$earlyCaptureRegistries() in MixinMinecraftServer so we can set this really early.
+        // Called by biolith$earlyCaptureRegistries() in MixinMinecraftServer and MixinServerLoad so we can set this really early.
         registryManager = combinedDynamicRegistries.getCombinedRegistryManager();
     }
 

--- a/src/main/java/com/terraformersmc/biolith/impl/mixin/MixinSaveLoader.java
+++ b/src/main/java/com/terraformersmc/biolith/impl/mixin/MixinSaveLoader.java
@@ -1,0 +1,27 @@
+package com.terraformersmc.biolith.impl.mixin;
+
+import net.minecraft.registry.CombinedDynamicRegistries;
+import net.minecraft.registry.ServerDynamicRegistryType;
+import net.minecraft.server.SaveLoader;
+
+import com.terraformersmc.biolith.impl.biome.BiomeCoordinator;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(value=SaveLoader.class, priority = 500)
+public class MixinSaveLoader {
+    @Shadow @Final private CombinedDynamicRegistries<ServerDynamicRegistryType> combinedDynamicRegistries;
+
+    @ModifyVariable(method = "<init>", argsOnly = true, at = @At(value = "INVOKE", target = "Ljava/lang/Record;<init>()V", shift = At.Shift.AFTER))
+    private CombinedDynamicRegistries<ServerDynamicRegistryType> biolith$earlyCaptureRegistries(
+            CombinedDynamicRegistries<ServerDynamicRegistryType> combinedDynamicRegistries
+    ) {
+        System.out.println("Biolith: early capture registries");
+        // We need the registries really early in case TerraBlender calls us before the Fabric server start event.
+        BiomeCoordinator.setRegistryManager(combinedDynamicRegistries);
+        return combinedDynamicRegistries;
+    }
+}

--- a/src/main/resources/biolith.mixins.json
+++ b/src/main/resources/biolith.mixins.json
@@ -11,6 +11,7 @@
     "MixinEntries",
     "MixinMinecraftServer",
     "MixinMultiNoiseBiomeSource",
+    "MixinSaveLoader",
     "MixinSearchTree",
     "MixinServerWorld",
     "MixinSurfaceBuilder",


### PR DESCRIPTION
This should fix a crashes related to BCLib by initialising the `registryManager´ before BCLib tries to set migrate the Biome-Data.

The call to `setRegistryManager` in `MixinMinecraftServer` may be redundant with this change, but it should not have any negative effect as it will simply capture the same registries.

This should solve quiqueck/BetterNether#138 and #4